### PR TITLE
add support for alt prop on FullsizePicture

### DIFF
--- a/src/components/FullsizePicture.jsx
+++ b/src/components/FullsizePicture.jsx
@@ -47,6 +47,7 @@ class FullSizePicture extends React.PureComponent {
             <div style={this.getStyles()}>
                 <div style={this.getImageWrapperStyles()}>
                     <Picture
+                        alt={this.props.alt}
                         src={this.props.src}
                         sources={this.props.sources}
                         style={this.getImageStyles()}
@@ -58,6 +59,7 @@ class FullSizePicture extends React.PureComponent {
 }
 
 FullSizePicture.propTypes = {
+    alt: React.PropTypes.string,
     sources: React.PropTypes.array,
     src: React.PropTypes.string,
     style: React.PropTypes.oneOfType([


### PR DESCRIPTION
@braposo, this closes #5. `Picture` already supported it, just not `FullsizePicture`.